### PR TITLE
fix reconstruction of path for upwards diagonal words

### DIFF
--- a/src/puzzle.py
+++ b/src/puzzle.py
@@ -82,7 +82,7 @@ class Puzzle:
                 for cx, c in enumerate(coords):
                     temp[cx].append(self.puzzle[c[0]][0][c[1]])
                     ranges[cx].append((c[0], c[1]))
-                    ranges[cx+4].append((c[1], c[0]))
+                    ranges[cx+4].insert(0, (c[0], c[1]))
                 i+=1
 
             for ti in range(4):


### PR DESCRIPTION
While the algorithm correctly detects upwards diagonals, the path is stored incorrectly in the `ranges`. Instead of just traversing backwards, x and y coordinates were interchanged, which makes no sense at all.

Example: 
Search for word: `SDRUK`

```
MRGSDQMRWGOBCNWX
VIOACOFISHERMANS
RQNBWEGXENUXWCGP
IDXCOAHKRWEOKDQC
GSSWAIQEUWONTGRR
BGDRIPLCDRMPRUSI
DKJXPWAKPFDFYLWE
CAXCQCHCDHDSXFUP
NLJSAUTGIMVNCPJC
YGTUJHYHOTLFQOGD
MCIGJDPXKOAXCREC
UIQLCECEPKUTCTUR
BGVKNLFAEBLOESPF
GMAXRLNHXCJSPASM
ELTFWFBIMSBQBPWN
KIIIFXTZPGZZSBSY
```

This commit fixes the issue :)